### PR TITLE
Feat/add visually hidden component

### DIFF
--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
@@ -15,7 +15,7 @@ export const Default: ComponentStory<typeof VisualyHidden> = (props) => {
 };
 
 Default.args = {
-	as: 'div',
+	tag: 'div',
 };
 
 export const VisibleOnFocus: ComponentStory<typeof VisualyHidden> = (props) => {
@@ -27,6 +27,6 @@ export const VisibleOnFocus: ComponentStory<typeof VisualyHidden> = (props) => {
 };
 
 VisibleOnFocus.args = {
-	as: 'div',
+	tag: 'div',
 	visibleOnFocus: true,
 };

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
@@ -15,7 +15,7 @@ export const Default: ComponentStory<typeof VisualyHidden> = (props) => {
 };
 
 Default.args = {
-	tag: 'div',
+	tag: 'span',
 };
 
 export const VisibleOnFocus: ComponentStory<typeof VisualyHidden> = (props) => {
@@ -27,6 +27,6 @@ export const VisibleOnFocus: ComponentStory<typeof VisualyHidden> = (props) => {
 };
 
 VisibleOnFocus.args = {
-	tag: 'div',
+	tag: 'span',
 	visibleOnFocus: true,
 };

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.stories.tsx
@@ -1,0 +1,32 @@
+import { VisualyHidden } from './visuallyHidden';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+	title: 'Main Library/atoms/VisualyHidden',
+	component: VisualyHidden,
+} as ComponentMeta<typeof VisualyHidden>;
+
+export const Default: ComponentStory<typeof VisualyHidden> = (props) => {
+	return (
+		<VisualyHidden {...props}>
+			<button>visually hidden content</button>
+		</VisualyHidden>
+	);
+};
+
+Default.args = {
+	as: 'div',
+};
+
+export const VisibleOnFocus: ComponentStory<typeof VisualyHidden> = (props) => {
+	return (
+		<VisualyHidden {...props}>
+			<button>visually hidden content</button>
+		</VisualyHidden>
+	);
+};
+
+VisibleOnFocus.args = {
+	as: 'div',
+	visibleOnFocus: true,
+};

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
@@ -1,0 +1,23 @@
+import cx from 'clsx';
+import { ReactNode } from 'react';
+
+type VisualyHiddenProps = {
+	children: ReactNode;
+	as?: 'div' | 'span';
+	visibleOnFocus?: boolean;
+};
+
+export const VisualyHidden = ({
+	children,
+	as = 'div',
+	visibleOnFocus,
+}: VisualyHiddenProps) => {
+	const HtmlTag = as;
+	return (
+		<HtmlTag
+			className={cx('sr-only', { 'focus-within:not-sr-only': visibleOnFocus })}
+		>
+			{children}
+		</HtmlTag>
+	);
+};

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
@@ -11,7 +11,7 @@ type VisualyHiddenProps = {
 
 export const VisualyHidden = ({
 	children,
-	tag: HtmlTag = 'div',
+	tag: HtmlTag = 'span',
 	visibleOnFocus,
 }: VisualyHiddenProps) => {
 	return (

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
@@ -11,10 +11,9 @@ type VisualyHiddenProps = {
 
 export const VisualyHidden = ({
 	children,
-	as = 'div',
+	as: HtmlTag = 'div',
 	visibleOnFocus,
 }: VisualyHiddenProps) => {
-	const HtmlTag = as;
 	return (
 		<HtmlTag
 			className={cx('sr-only', { 'focus-within:not-sr-only': visibleOnFocus })}

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
@@ -1,9 +1,11 @@
 import cx from 'clsx';
 import { ReactNode } from 'react';
 
+type ContainerType = keyof Pick<JSX.IntrinsicElements, 'div' | 'span'>;
+
 type VisualyHiddenProps = {
 	children: ReactNode;
-	as?: 'div' | 'span';
+	as?: ContainerType;
 	visibleOnFocus?: boolean;
 };
 

--- a/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
+++ b/apps/web/components/atoms/visuallyHidden/visuallyHidden.tsx
@@ -5,13 +5,13 @@ type ContainerType = keyof Pick<JSX.IntrinsicElements, 'div' | 'span'>;
 
 type VisualyHiddenProps = {
 	children: ReactNode;
-	as?: ContainerType;
+	tag?: ContainerType;
 	visibleOnFocus?: boolean;
 };
 
 export const VisualyHidden = ({
 	children,
-	as: HtmlTag = 'div',
+	tag: HtmlTag = 'div',
 	visibleOnFocus,
 }: VisualyHiddenProps) => {
 	return (


### PR DESCRIPTION
Komponent do wizualnego ukrywania elementów na stronie. Domyślnie komponent przybiera `<div>` jako kontener na zawartość, lecz można go zmienić na `<span>` ustawiając props `as`. Dodatkowo ustawiając props `visibleOnFocus` można umożliwić odkrywanie elementów podczas focusowania ich za pomocą klawiatury.